### PR TITLE
fix: catch errors from API as user errors

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,7 +6,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
+         stopOnFailure="true"
          syntaxCheck="false"
          bootstrap="tests/bootstrap.php">
 

--- a/src/Keboola/AdWordsExtractor/Extractor.php
+++ b/src/Keboola/AdWordsExtractor/Extractor.php
@@ -119,12 +119,12 @@ class Extractor
                                 isset($query['primary']) ? $query['primary'] : []
                             );
                         } catch (ApiException $e) {
-                            $this->output->getErrorOutput()->writeln("Getting report for client '{$parsedCustomer['name']}' failed:{$e->getMessage()}");
+                            $this->output->getErrorOutput()->writeln("Getting report for client '{$parsedCustomer['name']}' failed: {$e->getMessage()}");
                             $anyQueryFailed = true;
                         }
                     }
                 } catch (ApiException $e) {
-                    $this->output->getErrorOutput()->writeln("Getting data for client '{$parsedCustomer['name']}' failed:{$e->getMessage()}");
+                    $this->output->getErrorOutput()->writeln("Getting data for client '{$parsedCustomer['name']}' failed: {$e->getMessage()}");
                     $anyQueryFailed = true;
                 }
             }

--- a/src/Keboola/AdWordsExtractor/RunCommand.php
+++ b/src/Keboola/AdWordsExtractor/RunCommand.php
@@ -52,7 +52,11 @@ class RunCommand extends Command
 
             return 0;
         } catch (\GuzzleHttp\Exception\ClientException $e) {
-            $consoleOutput->writeln($e->getMessage());
+            $output = $e->getMessage();
+            if (strpos($e->getMessage(), 'invalid_grant') !== false) {
+                $output .= ' Try to re-authorize your component.';
+            }
+            $consoleOutput->writeln($output);
             return 1;
         } catch (ApiException $e) {
             $consoleOutput->writeln($e->getMessage());

--- a/src/Keboola/AdWordsExtractor/RunCommand.php
+++ b/src/Keboola/AdWordsExtractor/RunCommand.php
@@ -51,6 +51,9 @@ class RunCommand extends Command
             $app->extract($validatedConfig['queries'], $validatedConfig['since'], $validatedConfig['until']);
 
             return 0;
+        } catch (\GuzzleHttp\Exception\ClientException $e) {
+            $consoleOutput->writeln($e->getMessage());
+            return 1;
         } catch (ApiException $e) {
             $consoleOutput->writeln($e->getMessage());
             return 1;


### PR DESCRIPTION
Mělo se to odchytit tady: https://github.com/keboola/adwords-extractor/blob/cddcae879e65ebabed7be8336667f7f64862425b/src/Keboola/AdWordsExtractor/RunCommand.php#L54 ale zdá se, že to jejich šílený soapový sdk tu výjimku nepřeloží a zůstane `\GuzzleHttp\Exception\ClientException` (i když tvrdí opak: https://github.com/googleads/googleads-php-lib/blob/master/src/Google/AdsApi/AdWords/v201809/mcm/ManagedCustomerService.php#L99)