### PR TITLE
Fix optional developer token

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Uses [googleads-php-lib](https://github.com/googleads/googleads-php-lib) version
     - **bucket** - Name of bucket where the data will be saved
     - **since** *(optional)* - start date of downloaded stats (default is "-1 day")
     - **until** *(optional)* - end date of downloaded stats (default is "-1 day")
+    - **#developerToken** *(optional)* - client can use his own AdWords developer token
     - **queries** - Array of reports to download as Ad-hoc report, each item must contain:
         - **name** - Name of query, data will be saved to table `[bucket].[name]`.
         *Note that `customers` and `campaigns` are reserved names, thus cannot be used as query names.*

--- a/src/Keboola/AdWordsExtractor/Config.php
+++ b/src/Keboola/AdWordsExtractor/Config.php
@@ -21,6 +21,11 @@ class Config extends BaseConfig
 
     public function getDeveloperToken(): string
     {
+        $token = $this->getValue(['parameters', '#developerToken'], '');
+        if ($token) {
+            return $token;
+        }
+
         if (!isset($this->getImageParameters()['#developer_token'])) {
             throw new \Exception('Developer token is missing from image parameters');
         }

--- a/src/Keboola/AdWordsExtractor/ConfigDefinition.php
+++ b/src/Keboola/AdWordsExtractor/ConfigDefinition.php
@@ -19,6 +19,7 @@ class ConfigDefinition extends BaseConfigDefinition
             ->scalarNode('customerId')->isRequired()->cannotBeEmpty()->end()
             ->scalarNode('since')->end()
             ->scalarNode('until')->end()
+            ->scalarNode('#developerToken')->end()
             ->scalarNode('bucket')->end()
             ->arrayNode('queries')->isRequired()->cannotBeEmpty()->arrayPrototype()
             ->children()

--- a/tests/functional/DatadirTest.php
+++ b/tests/functional/DatadirTest.php
@@ -69,4 +69,41 @@ class DatadirTest extends AbstractDatadirTestCase
             $this->assertEquals('Campaign ID,Impressions,Clicks', trim($csv[0]));
         }
     }
+
+    public function testRunWithUserDefinedDeveloperToken(): void
+    {
+        $reportName = uniqid();
+        $config = [
+            'action' => 'run',
+            'parameters' => [
+                'customerId' => EX_AW_CUSTOMER_ID,
+                '#developerToken' => EX_AW_DEVELOPER_TOKEN,
+                'queries' => [
+                    [
+                        'name' => $reportName,
+                        'query' => 'SELECT CampaignId, Impressions, Clicks FROM CAMPAIGN_PERFORMANCE_REPORT',
+                        'primary' => ['CampaignId'],
+                    ],
+                ],
+            ],
+            'authorization' => ['oauth_api' => ['credentials' => [
+                'appKey' => EX_AW_CLIENT_ID,
+                '#appSecret' => EX_AW_CLIENT_SECRET,
+                '#data' => \GuzzleHttp\json_encode(['refresh_token' => EX_AW_REFRESH_TOKEN]),
+            ]]],
+            'image_parameters' => ['#developer_token' => 'invalid'],
+        ];
+
+        $specification = new DatadirTestSpecification(
+            __DIR__ . '/run/source/data',
+            0,
+            '',
+            '',
+        );
+        $tempDatadir = $this->getTempDatadir($specification);
+        file_put_contents($tempDatadir->getTmpFolder() . '/config.json', \GuzzleHttp\json_encode($config));
+        $process = $this->runScript($tempDatadir->getTmpFolder());
+        $this->assertEmpty($process->getErrorOutput());
+        $this->assertEquals(0, $process->getExitCode());
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/keboola/adwords-extractor/issues/27

AdWords developer token může mít klient svůj vlastní zadanej v parametrech. Na to se zapomnělo při přepisu do `keboola/php-component` (https://github.com/keboola/adwords-extractor/pull/26) a ten je teď revertnutý na předchozí verzi.